### PR TITLE
Guess non writable attributes

### DIFF
--- a/Tests/Behat/TestBundle/Entity/Dummy.php
+++ b/Tests/Behat/TestBundle/Entity/Dummy.php
@@ -28,13 +28,23 @@ class Dummy
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    public $id;
+    private $id;
 
     /**
      * @ORM\Column
      * @Assert\NotBlank
      */
     private $name;
+
+    /**
+     * @ORM\Column(nullable=true)
+     */
+    public $dummy;
+
+    public function getId()
+    {
+        return $this->id;
+    }
 
     public function setName($name)
     {

--- a/features/collection.feature
+++ b/features/collection.feature
@@ -26,17 +26,20 @@ Feature: Collections support
         {
           "@id": "/dummies/1",
           "@type": "Dummy",
-          "name": "Dummy #1"
+          "name": "Dummy #1",
+          "dummy": null
         },
         {
           "@id": "/dummies/2",
           "@type": "Dummy",
-          "name": "Dummy #2"
+          "name": "Dummy #2",
+          "dummy": null
         },
         {
           "@id": "/dummies/3",
           "@type": "Dummy",
-          "name": "Dummy #3"
+          "name": "Dummy #3",
+          "dummy": null
         }
       ]
     }
@@ -66,17 +69,20 @@ Feature: Collections support
         {
           "@id": "/dummies/19",
           "@type": "Dummy",
-          "name": "Dummy #19"
+          "name": "Dummy #19",
+          "dummy": null
         },
         {
           "@id": "/dummies/20",
           "@type": "Dummy",
-          "name": "Dummy #20"
+          "name": "Dummy #20",
+          "dummy": null
         },
         {
           "@id": "/dummies/21",
           "@type": "Dummy",
-          "name": "Dummy #21"
+          "name": "Dummy #21",
+          "dummy": null
         }
       ]
     }
@@ -105,17 +111,20 @@ Feature: Collections support
           {
             "@id": "/dummies/28",
             "@type": "Dummy",
-            "name": "Dummy #28"
+            "name": "Dummy #28",
+            "dummy": null
           },
           {
             "@id": "/dummies/29",
             "@type": "Dummy",
-            "name": "Dummy #29"
+            "name": "Dummy #29",
+            "dummy": null
           },
           {
             "@id": "/dummies/30",
             "@type": "Dummy",
-            "name": "Dummy #30"
+            "name": "Dummy #30",
+            "dummy": null
           }
       ]
     }

--- a/features/crud.feature
+++ b/features/crud.feature
@@ -20,7 +20,8 @@ Feature: Create-Retrieve-Update-Delete
       "@context": "/contexts/Dummy",
       "@id": "/dummies/1",
       "@type": "Dummy",
-      "name": "My Dummy"
+      "name": "My Dummy",
+      "dummy": null
     }
     """
 
@@ -35,7 +36,8 @@ Feature: Create-Retrieve-Update-Delete
       "@context": "/contexts/Dummy",
       "@id": "/dummies/1",
       "@type": "Dummy",
-      "name": "My Dummy"
+      "name": "My Dummy",
+      "dummy": null
     }
     """
 
@@ -58,7 +60,8 @@ Feature: Create-Retrieve-Update-Delete
         {
           "@id":"/dummies/1",
           "@type":"Dummy",
-          "name":"My Dummy"
+          "name":"My Dummy",
+          "dummy": null
         }
       ]
     }
@@ -81,7 +84,8 @@ Feature: Create-Retrieve-Update-Delete
         "@context": "/contexts/Dummy",
         "@id": "/dummies/1",
         "@type": "Dummy",
-        "name": "A nice dummy"
+        "name": "A nice dummy",
+        "dummy": null
       }
       """
 

--- a/features/vocab.feature
+++ b/features/vocab.feature
@@ -1,0 +1,106 @@
+Feature: Documentation support
+  In order to build an auto-discoverable API
+  As a client software developer
+  I need to know the specifications of objects I send and receive
+
+  @createSchema
+  @dropSchema
+  Scenario: Retrieve the first page of a collection
+    And I send a "GET" request to "/vocab"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "\/contexts\/ApiDocumentation",
+      "@id": "\/vocab",
+      "hydra:title": "My Dummy API",
+      "hydra:description": "This is a test API.",
+      "hydra:entrypoint": "\/",
+      "hydra:supportedClass": [
+        {
+          "@id": "Entrypoint",
+          "@type": "hydra:class",
+          "hydra:title": "The API entrypoint",
+          "hydra:supportedProperty": [
+            {
+              "@type": "hydra:SupportedProperty",
+              "hydra:property": "dummies",
+              "hydra:title": "The collection of Dummy resources",
+              "hydra:readable": true,
+              "hydra:writable": false,
+              "hydra:supportedOperation": [
+                {
+                  "@type": "hydra:Operation",
+                  "hydra:title": "Retrieves the collection of Dummy resources.",
+                  "hydra:returns": "hydra:PagedCollection",
+                  "hydra:method": "GET"
+                },
+                {
+                  "@type": "hydra:CreateResourceOperation",
+                  "hydra:title": "Creates a Dummy resource.",
+                  "hydra:expects": "Dummy",
+                  "hydra:returns": "Dummy",
+                  "hydra:method": "POST"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "@id": "Dummy",
+          "@type": "hydra:Class",
+          "hydra:title": "Dummy",
+          "hydra:description": "Dummy.",
+          "hydra:supportedProperty": [
+            {
+              "@type": "hydra:SupportedProperty",
+              "hydra:property": "Dummy\/id",
+              "hydra:title": "id",
+              "hydra:required": false,
+              "hydra:readable": true,
+              "hydra:writable": true
+            },
+            {
+              "@type": "hydra:SupportedProperty",
+              "hydra:property": "Dummy\/name",
+              "hydra:title": "name",
+              "hydra:required": true,
+              "hydra:readable": true,
+              "hydra:writable": true
+            },
+            {
+              "@type": "hydra:SupportedProperty",
+              "hydra:property": "Dummy\/dummy",
+              "hydra:title": "dummy",
+              "hydra:required": false,
+              "hydra:readable": true,
+              "hydra:writable": true
+            }
+          ],
+          "hydra:supportedOperation": [
+            {
+              "@type": "hydra:Operation",
+              "hydra:title": "Retrieves Dummy resource.",
+              "hydra:returns": "Dummy",
+              "hydra:method": "GET"
+            },
+            {
+              "@type": "hydra:ReplaceResourceOperation",
+              "hydra:title": "Replaces the Dummy resource.",
+              "hydra:expects": "Dummy",
+              "hydra:returns": "Dummy",
+              "hydra:method": "PUT"
+            },
+            {
+              "@type": "hydra:Operation",
+              "hydra:title": "Deletes the Dummy resource.",
+              "hydra:expects": "Dummy",
+              "hydra:method": "DELETE"
+            }
+          ]
+        }
+      ]
+    }
+    """

--- a/features/vocab.feature
+++ b/features/vocab.feature
@@ -60,7 +60,7 @@ Feature: Documentation support
               "hydra:title": "id",
               "hydra:required": false,
               "hydra:readable": true,
-              "hydra:writable": true
+              "hydra:writable": false
             },
             {
               "@type": "hydra:SupportedProperty",


### PR DESCRIPTION
By looking for getters and setters to determine if a property is readable and/or writable, we're able to easily detect non-writable fields such as entities' `id`.