### PR TITLE
Prepend serializer configuration when not enabled

### DIFF
--- a/DependencyInjection/DunglasJsonLdApiExtension.php
+++ b/DependencyInjection/DunglasJsonLdApiExtension.php
@@ -34,6 +34,16 @@ class DunglasJsonLdApiExtension extends Extension implements PrependExtensionInt
         if (isset($container->getParameter('kernel.bundles')['FOSUserBundle'])) {
             $container->prependExtensionConfig($this->getAlias(), ['enable_fos_user_event_subscriber' => true]);
         }
+
+        if (null !== ($frameworkConfiguration = $container->getExtensionConfig('framework'))) {
+            if (!isset($frameworkConfiguration['serializer']) || !isset($frameworkConfiguration['serializer']['enabled'])) {
+                $container->prependExtensionConfig('framework', [
+                    'serializer' => [
+                        'enabled' => true
+                    ]
+                ]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When the `framework.serializer.enabled` configuration is not explicitly to `true`, the `serializer` service won't be able and controller will fail trying to get it from container.

To improve DX, this prepend configuration will enable the `serializer` service if configuration is not explicitly defined.