### PR TITLE
Exception serialization to `hydra:Error`

### DIFF
--- a/Controller/DocumentationController.php
+++ b/Controller/DocumentationController.php
@@ -25,6 +25,7 @@ class DocumentationController extends Controller
         'Entrypoint' => true,
         'ConstraintViolationList' => true,
         'ApiDocumentation' => true,
+        'Error' => true,
     ];
 
     /**

--- a/EventListener/RequestExceptionListener.php
+++ b/EventListener/RequestExceptionListener.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\JsonLdApiBundle\EventListener;
+
+use Dunglas\JsonLdApiBundle\Exception\DeserializationException;
+use Dunglas\JsonLdApiBundle\Response\JsonLdResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Handle requests errors.
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ */
+class RequestExceptionListener
+{
+    /**
+     * @var NormalizerInterface
+     */
+    private $normalizer;
+
+    /**
+     * @param NormalizerInterface $normalizer
+     */
+    public function __construct(NormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $exception = $event->getException();
+
+        // Normalize exceptions with hydra errors only for resources
+        if ($request->attributes->has('_json_ld_resource')) {
+            $event->setResponse(new JsonLdResponse(
+                $this->normalizer->normalize($exception, 'hydra-error'),
+                $exception instanceof DeserializationException ? 400 : 500
+            ));
+        }
+    }
+}

--- a/EventListener/RequestExceptionListener.php
+++ b/EventListener/RequestExceptionListener.php
@@ -13,6 +13,7 @@ namespace Dunglas\JsonLdApiBundle\EventListener;
 
 use Dunglas\JsonLdApiBundle\Exception\DeserializationException;
 use Dunglas\JsonLdApiBundle\Response\JsonLdResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -53,7 +54,7 @@ class RequestExceptionListener
         if ($request->attributes->has('_json_ld_resource')) {
             $event->setResponse(new JsonLdResponse(
                 $this->normalizer->normalize($exception, 'hydra-error'),
-                $exception instanceof DeserializationException ? 400 : 500
+                $exception instanceof DeserializationException ? Response::HTTP_BAD_REQUEST : Response::HTTP_INTERNAL_SERVER_ERROR
             ));
         }
     }

--- a/Exception/DeserializationException.php
+++ b/Exception/DeserializationException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\JsonLdApiBundle\Exception;
+
+use Symfony\Component\Serializer\Exception\Exception;
+
+/**
+ * Deserialization exception
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ */
+class DeserializationException extends \Exception implements Exception
+{
+}

--- a/Resources/config/api.xml
+++ b/Resources/config/api.xml
@@ -45,6 +45,12 @@
             <tag name="serializer.normalizer" />
         </service>
 
+        <service id="dunglas_json_ld_api.error_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\ErrorNormalizer" public="false">
+            <argument type="service" id="dunglas_json_ld_api.router" />
+
+            <tag name="serializer.normalizer" />
+        </service>
+
         <service id="dunglas_json_ld_api.json_ld_encoder" class="Dunglas\JsonLdApiBundle\Serializer\JsonLdEncoder" public="false">
             <tag name="serializer.encoder" />
         </service>
@@ -58,6 +64,11 @@
         <service id="dunglas_json_ld_api.context_builder" class="Dunglas\JsonLdApiBundle\JsonLd\ContextBuilder">
             <argument type="service" id="dunglas_json_ld_api.router" />
             <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
+        </service>
+
+        <service id="dunglas_json_ld_api.exception_listener" class="Dunglas\JsonLdApiBundle\EventListener\RequestExceptionListener">
+            <argument type="service" id="dunglas_json_ld_api.error_normalizer" />
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
     </services>
 

--- a/Serializer/ErrorNormalizer.php
+++ b/Serializer/ErrorNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\JsonLdApiBundle\Serializer;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Converts {@see \Exception} to a Hydra error representation.
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ */
+class ErrorNormalizer implements NormalizerInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        if ($object instanceof \Exception) {
+            $message = $object->getMessage();
+        }
+
+        return [
+            '@context' => $this->router->generate('json_ld_api_context', ['shortName' => 'Error']),
+            '@type' => 'Error',
+            'hydra:title' => isset($context['title']) ? $context['title'] : 'An error occurred',
+            'hydra:description' => isset($message) ? $message : (string) $object,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return 'hydra-error' === $format && $data instanceof \Exception;
+    }
+}

--- a/Serializer/JsonLdNormalizer.php
+++ b/Serializer/JsonLdNormalizer.php
@@ -266,7 +266,7 @@ class JsonLdNormalizer extends AbstractNormalizer
                         foreach ($value as $uri) {
                             if (!is_string($uri)) {
                                 throw new InvalidArgumentException(sprintf(
-                                    'Nested object are not supported (found in attribute "%s")',
+                                    'Nested objects are not supported (found in attribute "%s")',
                                     $attribute
                                 ));
                             }
@@ -275,7 +275,7 @@ class JsonLdNormalizer extends AbstractNormalizer
                         }
 
                         $value = $collection;
-                    } else if (is_string($value)) {
+                    } elseif (is_string($value)) {
                         $value = $this->dataManipulator->getObjectFromUri($value);
                     } else {
                         throw new InvalidArgumentException(sprintf(

--- a/Serializer/JsonLdNormalizer.php
+++ b/Serializer/JsonLdNormalizer.php
@@ -264,12 +264,25 @@ class JsonLdNormalizer extends AbstractNormalizer
                     if ($attributes[$attribute]->getTypes()[0]->isCollection()) {
                         $collection = [];
                         foreach ($value as $uri) {
+                            if (!is_string($uri)) {
+                                throw new InvalidArgumentException(sprintf(
+                                    'Nested object are not supported (found in attribute "%s")',
+                                    $attribute
+                                ));
+                            }
+
                             $collection[] = $this->dataManipulator->getObjectFromUri($uri);
                         }
 
                         $value = $collection;
-                    } else {
+                    } else if (is_string($value)) {
                         $value = $this->dataManipulator->getObjectFromUri($value);
+                    } else {
+                        throw new InvalidArgumentException(sprintf(
+                            'Type not supported (found "%s" in attribute "%s")',
+                            gettype($value),
+                            $attribute
+                        ));
                     }
                 }
 

--- a/features/error.feature
+++ b/features/error.feature
@@ -27,7 +27,7 @@ Feature: Error handling
     }
     """
 
-  Scenario: Get an error during deserialization
+  Scenario: Get an error during deserialization of simple relation
     Given I send a "POST" request to "/dummies" with body:
     """
     {
@@ -50,7 +50,7 @@ Feature: Error handling
     }
     """
 
-  Scenario: Get an error during deserialization
+  Scenario: Get an error during deserialization of collection
     Given I send a "POST" request to "/dummies" with body:
     """
     {
@@ -69,6 +69,26 @@ Feature: Error handling
       "@context": "/contexts/Error",
       "@type": "Error",
       "hydra:title": "An error occurred",
-      "hydra:description": "Nested object are not supported (found in attribute \"relatedDummies\")"
+      "hydra:description": "Nested objects are not supported (found in attribute \"relatedDummies\")"
+    }
+    """
+
+    Scenario: Get an error because of an invalid JSON
+    Given I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Foo",
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Error",
+      "@type": "Error",
+      "hydra:title": "An error occurred",
+      "hydra:description": "Syntax error"
     }
     """

--- a/features/error.feature
+++ b/features/error.feature
@@ -26,3 +26,49 @@ Feature: Error handling
       ]
     }
     """
+
+  Scenario: Get an error during deserialization
+    Given I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Foo",
+      "relatedDummy": {
+        "name": "bar"
+      }
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Error",
+      "@type": "Error",
+      "hydra:title": "An error occurred",
+      "hydra:description": "Type not supported (found \"array\" in attribute \"relatedDummy\")"
+    }
+    """
+
+  Scenario: Get an error during deserialization
+    Given I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Foo",
+      "relatedDummies": [{
+        "name": "bar"
+      }]
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Error",
+      "@type": "Error",
+      "hydra:title": "An error occurred",
+      "hydra:description": "Nested object are not supported (found in attribute \"relatedDummies\")"
+    }
+    """


### PR DESCRIPTION
This PR add support of `Exception` serialization into `hydra:Error` objects. 
It also add checks the types of given objects for relations and eventually throw exceptions in case of error.