### PR TITLE
Explode JsonLdNormalizer into smaller ones

### DIFF
--- a/JsonLd/ContextBuilder.php
+++ b/JsonLd/ContextBuilder.php
@@ -137,15 +137,33 @@ class ContextBuilder
     public function bootstrap(Resource $resource, array $context = [])
     {
         $data = [];
-        if (!isset($context['has_json_ld_context'])) {
+        if (!isset($context['json_ld_has_context'])) {
             $data['@context'] = $this->router->generate(
                 'json_ld_api_context',
                 ['shortName' => $resource->getShortName()]
             );
-            $context['has_json_ld_context'] = true;
+            $context['json_ld_has_context'] = true;
         }
 
         return [$context, $data];
+    }
+
+    /**
+     * Bootstrap relation context.
+     *
+     * @param Resource $resource
+     * @param $class
+     * @return array
+     */
+    public function bootstrapRelation(Resource $resource, $class)
+    {
+        return [
+            'resource' => $this->resources->getResourceForEntity($class),
+            'json_ld_has_context' => true,
+            'json_ld_normalization_groups' => $resource->getNormalizationGroups(),
+            'json_ld_denormalization_groups' => $resource->getDenormalizationGroups(),
+            'json_ld_validation_groups' => $resource->getValidationGroups(),
+        ];
     }
 
     /**

--- a/JsonLd/ContextBuilder.php
+++ b/JsonLd/ContextBuilder.php
@@ -128,6 +128,27 @@ class ContextBuilder
     }
 
     /**
+     * Bootstrap a serialization context with the given resource.
+     *
+     * @param Resource $resource
+     * @param array $context
+     * @return array [array, array]
+     */
+    public function bootstrap(Resource $resource, array $context = [])
+    {
+        $data = [];
+        if (!isset($context['has_json_ld_context'])) {
+            $data['@context'] = $this->router->generate(
+                'json_ld_api_context',
+                ['shortName' => $resource->getShortName()]
+            );
+            $context['has_json_ld_context'] = true;
+        }
+
+        return [$context, $data];
+    }
+
+    /**
      * Gets the base context.
      *
      * @return array

--- a/Resources/config/api.xml
+++ b/Resources/config/api.xml
@@ -67,6 +67,13 @@
             <tag name="serializer.normalizer" priority="50" />
         </service>
 
+        <service id="dunglas_json_ld_api.collection_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\CollectionNormalizer" public="false">
+            <argument type="service" id="dunglas_json_ld_api.resource_resolver" />
+            <argument type="service" id="dunglas_json_ld_api.router" />
+
+            <tag name="serializer.normalizer" priority="50" />
+        </service>
+
         <service id="dunglas_json_ld_api.json_ld_encoder" class="Dunglas\JsonLdApiBundle\Serializer\JsonLdEncoder" public="false">
             <tag name="serializer.encoder" />
         </service>

--- a/Resources/config/api.xml
+++ b/Resources/config/api.xml
@@ -46,6 +46,7 @@
             <argument type="service" id="dunglas_json_ld_api.router" />
             <argument type="service" id="dunglas_json_ld_api.data_manipulator" />
             <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />
+            <argument type="service" id="dunglas_json_ld_api.context_builder" />
 
             <tag name="serializer.normalizer" />
         </service>
@@ -70,6 +71,7 @@
         <service id="dunglas_json_ld_api.collection_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\CollectionNormalizer" public="false">
             <argument type="service" id="dunglas_json_ld_api.resource_resolver" />
             <argument type="service" id="dunglas_json_ld_api.router" />
+            <argument type="service" id="dunglas_json_ld_api.context_builder" />
 
             <tag name="serializer.normalizer" priority="50" />
         </service>

--- a/Resources/config/api.xml
+++ b/Resources/config/api.xml
@@ -37,8 +37,12 @@
             <argument type="service" id="dunglas_json_ld_api.resources" />
         </service>
 
-        <service id="dunglas_json_ld_api.json_ld_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\JsonLdNormalizer" public="false">
+        <service id="dunglas_json_ld_api.resource_resolver" class="Dunglas\JsonLdApiBundle\Serializer\ResourceResolver">
             <argument type="service" id="dunglas_json_ld_api.resources" />
+        </service>
+
+        <service id="dunglas_json_ld_api.json_ld_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\JsonLdNormalizer" public="false">
+            <argument type="service" id="dunglas_json_ld_api.resource_resolver" />
             <argument type="service" id="dunglas_json_ld_api.router" />
             <argument type="service" id="dunglas_json_ld_api.data_manipulator" />
             <argument type="service" id="dunglas_json_ld_api.mapping.class_metadata_factory" />

--- a/Resources/config/api.xml
+++ b/Resources/config/api.xml
@@ -59,6 +59,10 @@
             <tag name="serializer.normalizer" />
         </service>
 
+        <service id="dunglas_json_ld_api.datetime_normalizer" class="Dunglas\JsonLdApiBundle\Serializer\DateTimeNormalizer" public="false">
+            <tag name="serializer.normalizer" priority="50" />
+        </service>
+
         <service id="dunglas_json_ld_api.json_ld_encoder" class="Dunglas\JsonLdApiBundle\Serializer\JsonLdEncoder" public="false">
             <tag name="serializer.encoder" />
         </service>

--- a/Serializer/CollectionNormalizer.php
+++ b/Serializer/CollectionNormalizer.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Dunglas\JsonLdApiBundle\Serializer;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -6,6 +16,12 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
 
+/**
+ * This normalizer handle collections and paginated collections.
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ * @author Kevin Dunglas <dunglas@gmail.com>
+ */
 class CollectionNormalizer extends SerializerAwareNormalizer implements NormalizerInterface
 {
     const HYDRA_COLLECTION = 'hydra:Collection';

--- a/Serializer/CollectionNormalizer.php
+++ b/Serializer/CollectionNormalizer.php
@@ -71,7 +71,7 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
         $resource = $this->resourceResolver->guessResource($object, $context);
         list($context, $data) = $this->contextBuilder->bootstrap($resource, $context);
 
-        if (isset($context['sub_level'])) {
+        if (isset($context['json_ld_sub_level'])) {
             $data = [];
             foreach ($object as $obj) {
                 $data[] = $this->serializer->normalize($obj, $format, $context);

--- a/Serializer/CollectionNormalizer.php
+++ b/Serializer/CollectionNormalizer.php
@@ -1,0 +1,105 @@
+<?php
+namespace Dunglas\JsonLdApiBundle\Serializer;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class CollectionNormalizer extends SerializerAwareNormalizer implements NormalizerInterface
+{
+    const HYDRA_COLLECTION = 'hydra:Collection';
+    const HYDRA_PAGED_COLLECTION = 'hydra:PagedCollection';
+
+    /**
+     * @var ResourceResolver
+     */
+    private $resourceResolver;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param ResourceResolver $resourceResolver
+     * @param RouterInterface $router
+     */
+    public function __construct(ResourceResolver $resourceResolver, RouterInterface $router)
+    {
+        $this->resourceResolver = $resourceResolver;
+        $this->router = $router;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return 'json-ld' === $format && (is_array($data) || $data instanceof \Traversable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $resource = $this->resourceResolver->guessResource($object, $context);
+
+        $data = [];
+        if (!isset($context['has_json_ld_context'])) {
+            $data['@context'] = $this->router->generate(
+                'json_ld_api_context',
+                ['shortName' => $resource->getShortName()]
+            );
+            $context['has_json_ld_context'] = true;
+        }
+
+        if (isset($context['sub_level'])) {
+            $data = [];
+            foreach ($object as $obj) {
+                $data[] = $this->serializer->normalize($obj, $format, $context);
+            }
+        } else {
+            $data['@id'] = $this->router->generate($resource->getCollectionRoute());
+
+            if ($object instanceof Paginator) {
+                $data['@type'] = self::HYDRA_PAGED_COLLECTION;
+
+                $query = $object->getQuery();
+                $firstResult = $query->getFirstResult();
+                $maxResults = $query->getMaxResults();
+                $currentPage = floor($firstResult / $maxResults) + 1.;
+                $totalItems = count($object);
+                $lastPage = ceil($totalItems / $maxResults) ?: 1.;
+
+                $baseUrl = $data['@id'];
+                $paginatedUrl = $baseUrl.'?page=';
+
+                if (1. !== $currentPage) {
+                    $previousPage = $currentPage - 1.;
+                    $data['@id'] .= $paginatedUrl.$currentPage;
+                    $data['hydra:previousPage'] = 1. === $previousPage ? $baseUrl : $paginatedUrl.$previousPage;
+                }
+
+                if ($currentPage !== $lastPage) {
+                    $data['hydra:nextPage'] = $paginatedUrl.($currentPage + 1.);
+                }
+
+                $data['hydra:totalItems'] = $totalItems;
+                $data['hydra:itemsPerPage'] = $maxResults;
+                $data['hydra:firstPage'] = $baseUrl;
+                $data['hydra:lastPage'] = 1. === $lastPage ? $baseUrl : $paginatedUrl.$lastPage;
+            } else {
+                $data['@type'] = self::HYDRA_COLLECTION;
+            }
+
+            $data['hydra:member'] = [];
+            foreach ($object as $obj) {
+                $data['hydra:member'][] = $this->serializer->normalize($obj, $format, $context);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/Serializer/DateTimeNormalizer.php
+++ b/Serializer/DateTimeNormalizer.php
@@ -14,7 +14,7 @@ namespace Dunglas\JsonLdApiBundle\Serializer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * The `DateTime` object normalizer.
+ * The {@link \DateTime} object normalizer.
  *
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */

--- a/Serializer/DateTimeNormalizer.php
+++ b/Serializer/DateTimeNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\JsonLdApiBundle\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * The `DateTime` object normalizer.
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ */
+class DateTimeNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return 'json-ld' === $format && $data instanceof \DateTime;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        return $object->format(\DateTime::ATOM);
+    }
+}

--- a/Serializer/JsonLdNormalizer.php
+++ b/Serializer/JsonLdNormalizer.php
@@ -112,7 +112,7 @@ class JsonLdNormalizer extends AbstractNormalizer
             if (isset($context['json_ld_sub_level'])) {
                 $data = [];
                 foreach ($object as $obj) {
-                    $data[] = $this->normalize($obj, $format, $context);
+                    $data[] = $this->serializer->normalize($obj, $format, $context);
                 }
             } else {
                 $data['@id'] = $this->router->generate($resource->getCollectionRoute());
@@ -197,11 +197,7 @@ class JsonLdNormalizer extends AbstractNormalizer
                     }
                 }
 
-                if ($attributeValue instanceof \DateTime) {
-                    $attributeValue = $attributeValue->format(\DateTime::ATOM);
-                }
-
-                $data[$attributeName] = $this->serializer->normalize($attributeValue, 'json', $context);
+                $data[$attributeName] = $this->serializer->normalize($attributeValue, 'json-ld', $context);
             }
         }
 

--- a/Serializer/ResourceResolver.php
+++ b/Serializer/ResourceResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the DunglasJsonLdApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\JsonLdApiBundle\Serializer;
+
+use Dunglas\JsonLdApiBundle\JsonLd\Resources;
+use PropertyInfo\Type;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * This class helps to guess which resource is associated with a given object.
+ *
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ */
+class ResourceResolver
+{
+    /**
+     * @var Resources
+     */
+    private $resources;
+
+    /**
+     * @param Resources $resources
+     */
+    public function __construct(Resources $resources)
+    {
+        $this->resources = $resources;
+    }
+
+    /**
+     * Guesses the associated resource.
+     *
+     * @param mixed      $type
+     * @param array|null $context
+     *
+     * @return \Dunglas\JsonLdApiBundle\JsonLd\Resource
+     *
+     * @throws InvalidArgumentException
+     */
+    public function guessResource($type, array $context = null)
+    {
+        if (isset($context['resource'])) {
+            return $context['resource'];
+        }
+
+        if (is_object($type)) {
+            $type = get_class($type);
+        }
+
+        if (!is_string($type)) {
+            $type = gettype($type);
+        }
+
+        if ($resource = $this->resources->getResourceForEntity($type)) {
+            return $resource;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Cannot find a resource object for type "%s".', $type)
+        );
+    }
+
+    /**
+     * Returns the class if a resource is associated with it.
+     *
+     * @param Type $type
+     *
+     * @return string|null
+     */
+    public function getClassHavingResource(Type $type)
+    {
+        if (
+            'object' === $type->getType() &&
+            ($class = $type->getClass()) &&
+            $this->resources->getResourceForEntity($class)
+        ) {
+            return $class;
+        }
+    }
+}

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -95,7 +95,6 @@ Feature: Relations support
       Then the response status code should be 201
       And the response should be in JSON
       And the header "Content-Type" should be equal to "application/ld+json"
-      And print last JSON response
       And the JSON should be equal to:
       """
       {


### PR DESCRIPTION
This PR fixes #9: it splits the `JsonLdNormalizer` by creating two new normalizers:
- `CollectionNormalizer` that handles collections
- `DateTimeNormalier` that just handle `DateTime` objects

A new `ResourceResolver` class is also created to extract the resource guessing from normalizers and use that resolver in normalizers.
