### PR TITLE
Remove `PaginatorInterface::getMembers` since it's not used

### DIFF
--- a/Doctrine/Orm/Paginator.php
+++ b/Doctrine/Orm/Paginator.php
@@ -83,14 +83,6 @@ class Paginator implements \IteratorAggregate, PaginatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getMembers()
-    {
-        return $this->paginator;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getIterator()
     {
         return $this->paginator->getIterator();

--- a/Model/PaginatorInterface.php
+++ b/Model/PaginatorInterface.php
@@ -45,11 +45,4 @@ interface PaginatorInterface extends \Traversable
      * @return float
      */
     public function getTotalItems();
-
-    /**
-     * Gets members of this page.
-     *
-     * @return array|\Traversable
-     */
-    public function getMembers();
 }


### PR DESCRIPTION
The `getMembers` method of `PaginatorInterface` is not used because the interface extends `Traversable`.

This PR simply remove it and its implementation in Doctrine ORM paginator.
