### PR TITLE
Fixes an call on non-object if non docblock found

### DIFF
--- a/Mapping/ClassMetadataFactory.php
+++ b/Mapping/ClassMetadataFactory.php
@@ -135,7 +135,9 @@ class ClassMetadataFactory
         }
 
         if ($classReflector = $this->getClassReflector($classMetadata->getReflectionClass())) {
-            $classMetadata->setDescription($classReflector->getDocBlock()->getShortDescription());
+            if (null !== ($docBlock = $classReflector->getDocBlock())) {
+                $classMetadata->setDescription($docBlock->getShortDescription());
+            }
         }
 
         $this->loadAttributes(


### PR DESCRIPTION
The `getDocBlock` method can return null and if it's the case, there's a beautiful core error :sunglasses: 