### PR TITLE
Allow shortName to contain a slash

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -19,5 +19,6 @@
 
     <route id="json_ld_api_context" path="/contexts/{shortName}">
         <default key="_controller">DunglasJsonLdApiBundle:Documentation:context</default>
+        <requirement key="shortName">.+</requirement>
     </route>
 </routes>


### PR DESCRIPTION
Right now, short names of resources can't contain a slash and this PR fixes that issue.