### PR TITLE
Check that resolved resource is matching the object type

### DIFF
--- a/Serializer/ItemNormalizer.php
+++ b/Serializer/ItemNormalizer.php
@@ -86,7 +86,7 @@ class ItemNormalizer extends AbstractNormalizer
             return $this->handleCircularReference($object);
         }
 
-        $resource = $this->guessResource($object, $context);
+        $resource = $this->guessResource($object, $context, true);
         list($context, $data) = $this->contextBuilder->bootstrap($resource, $context);
 
         // Don't use hydra:Collection in sub levels

--- a/Tests/Behat/TestBundle/Entity/UnknownDummy.php
+++ b/Tests/Behat/TestBundle/Entity/UnknownDummy.php
@@ -11,40 +11,26 @@
 
 namespace Dunglas\JsonLdApiBundle\Tests\Behat\TestBundle\Entity;
 
-use Dunglas\JsonLdApiBundle\Annotation\Iri;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Annotation\Groups;
+use Dunglas\JsonLdApiBundle\Annotation\Iri;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * Related Dummy.
- *
- * @author Kévin Dunglas <dunglas@gmail.com>
+ * UnknownDummy.
  *
  * @ORM\Entity
- * @Iri("https://schema.org/Product")
  */
-class RelatedDummy extends ParentDummy
+class UnknownDummy
 {
     /**
+     * @var int The id.
+     *
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-    /**
-     * @ORM\Column
-     * @Groups({"barcelona"})
-     */
-    public $symfony = 'symfony';
-    /**
-     * @ORM\ManyToOne(targetEntity="UnknownDummy", cascade={"persist"})
-     */
-    public $unknown;
-
-    public function setUnknown()
-    {
-        $this->unknown = new UnknownDummy();
-    }
 
     public function getId()
     {

--- a/features/error.feature
+++ b/features/error.feature
@@ -80,3 +80,16 @@ Feature: Error handling
     And the JSON node "hydra:title" should be equal to "An error occurred"
     And the JSON node "hydra:description" should be equal to 'Syntax error'
     And the JSON node "trace" should exist
+
+  Scenario: I can't normalize unknown resources
+    Given I send a "POST" request to "/related_dummies" with body:
+    """
+    {
+      "unknown": "foo"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the JSON node "@context" should be equal to "/contexts/Error"
+    And the JSON node "@type" should be equal to "Error"
+    And the JSON node "hydra:description" should contain "Property type not supported"

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -18,6 +18,7 @@ Feature: Relations support
       "@context": "/contexts/RelatedDummy",
       "@id": "/related_dummies/1",
       "@type": "https://schema.org/Product",
+      "unknown": null,
       "age": null,
       "symfony": "symfony"
     }

--- a/features/vocab.feature
+++ b/features/vocab.feature
@@ -180,6 +180,19 @@ Feature: Documentation support
                     {
                         "@type": "hydra:SupportedProperty",
                         "hydra:property": {
+                            "@id": "#RelatedDummy\/unknown",
+                            "@type": "rdf:Property",
+                            "rdfs:label": "unknown",
+                            "domain": "https://schema.org/Product"
+                        },
+                        "hydra:title": "unknown",
+                        "hydra:required": false,
+                        "hydra:readable": true,
+                        "hydra:writable": true
+                    },
+                    {
+                        "@type": "hydra:SupportedProperty",
+                        "hydra:property": {
                             "@id": "#RelatedDummy/age",
                             "@type": "rdf:Property",
                             "rdfs:label": "age",


### PR DESCRIPTION
This add a check on resolved resources: it must match the object type, and resource don't come directly from the normalization context.

That's way we can display an explicit error message instead of having strange "unknown properties" errors.